### PR TITLE
bug: fixing include in workflows

### DIFF
--- a/addons/github-workflows/@{{ cookiecutter.project_slug }}/.github/workflows/app.yaml
+++ b/addons/github-workflows/@{{ cookiecutter.project_slug }}/.github/workflows/app.yaml
@@ -27,8 +27,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        stack: [app]
         {%- if cookiecutter.github_environments %}
+        stack: [app]
         environment:
           {%- for env in cookiecutter.environments %}
           - @{{ env }}
@@ -62,8 +62,8 @@ jobs:
     needs: [build_push]
     strategy:
       matrix:
-        stack: [app]
         {%- if cookiecutter.github_environments %}
+        stack: [app]
         environment: ['dev']
         {%- else%}
         include:
@@ -83,9 +83,9 @@ jobs:
       {%- else %}
       aws_region: ${{ matrix.aws_region }}
       aws_oidc_role_arn: arn:aws:iam::${{ matrix.aws_account_id }}:role/${{ matrix.aws_role_name }}
-      tf_dir: deploy/${{ matrix.stack }}
-      tf_backend_config_files: "deploy/${{ matrix.stack }}/environments/${{ matrix.environment }}.s3.tfbackend"
-      tf_var_files: "deploy/${{ matrix.stack }}/environments/${{ matrix.environment }}.tfvars"
+      tf_dir: deploy/app
+      tf_backend_config_files: "deploy/app/environments/${{ matrix.environment }}.s3.tfbackend"
+      tf_var_files: "deploy/app/environments/${{ matrix.environment }}.tfvars"
       {%- endif %}
   {%- endif %}
 
@@ -96,8 +96,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        stack: [app]
         {%- if cookiecutter.github_environments %}
+        stack: [app]
         environment:
           {%- for env in cookiecutter.environments %}
           - @{{ env }}
@@ -120,9 +120,9 @@ jobs:
       {%- else %}
       aws_region: ${{ matrix.aws_region }}
       aws_oidc_role_arn: arn:aws:iam::${{ matrix.aws_account_id }}:role/${{ matrix.aws_role_name }}
-      tf_dir: deploy/${{ matrix.stack }}
-      tf_backend_config_files: "deploy/${{ matrix.stack }}/environments/${{ matrix.environment }}.s3.tfbackend"
-      tf_var_files: "deploy/${{ matrix.stack }}/environments/${{ matrix.environment }}.tfvars"
+      tf_dir: deploy/app
+      tf_backend_config_files: "deploy/app/environments/${{ matrix.environment }}.s3.tfbackend"
+      tf_var_files: "deploy/app/environments/${{ matrix.environment }}.tfvars"
       {%- endif %}
 
   apply:
@@ -133,8 +133,8 @@ jobs:
       fail-fast: true
       max-parallel: 1
       matrix:
-        stack: [app]
         {%- if cookiecutter.github_environments %}
+        stack: [app]
         environment:
           {%- for env in cookiecutter.environments %}
           - @{{ env }}
@@ -157,7 +157,7 @@ jobs:
       {%- else %}
       aws_region: ${{ matrix.aws_region }}
       aws_oidc_role_arn: arn:aws:iam::${{ matrix.aws_account_id }}:role/${{ matrix.aws_role_name }}
-      tf_dir: deploy/${{ matrix.stack }}
-      tf_backend_config_files: "deploy/${{ matrix.stack }}/environments/${{ matrix.environment }}.s3.tfbackend"
-      tf_var_files: "deploy/${{ matrix.stack }}/environments/${{ matrix.environment }}.tfvars"
+      tf_dir: deploy/app
+      tf_backend_config_files: "deploy/app/environments/${{ matrix.environment }}.s3.tfbackend"
+      tf_var_files: "deploy/app/environments/${{ matrix.environment }}.tfvars"
       {%- endif %}

--- a/addons/github-workflows/@{{ cookiecutter.project_slug }}/.github/workflows/infra.yaml
+++ b/addons/github-workflows/@{{ cookiecutter.project_slug }}/.github/workflows/infra.yaml
@@ -26,8 +26,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        stack: [infra]
         {%- if cookiecutter.github_environments %}
+        stack: [infra]
         environment:
           {%- for env in cookiecutter.environments %}
           - @{{ env }}
@@ -49,8 +49,8 @@ jobs:
       aws_region: ${{ matrix.aws_region }}
       aws_oidc_role_arn: arn:aws:iam::${{ matrix.aws_account_id }}:role/${{ matrix.aws_role_name }}
       tf_dir: "deploy/infra"
-      tf_backend_config_files: "deploy/${{ matrix.stack }}/environments/${{ matrix.environment }}.s3.tfbackend"
-      tf_var_files: "deploy/${{ matrix.stack }}/environments/${{ matrix.environment }}.tfvars"
+      tf_backend_config_files: "deploy/infra}/environments/${{ matrix.environment }}.s3.tfbackend"
+      tf_var_files: "deploy/infra/environments/${{ matrix.environment }}.tfvars"
       {%- endif %}
 
 
@@ -60,8 +60,8 @@ jobs:
       fail-fast: true
       max-parallel: 1
       matrix:
-        stack: [infra]
         {%- if cookiecutter.github_environments %}
+        stack: [infra]
         environment:
           {%- for env in cookiecutter.environments %}
           - @{{ env }}
@@ -82,7 +82,7 @@ jobs:
       {%- else %}
       aws_region: ${{ matrix.aws_region }}
       aws_oidc_role_arn: arn:aws:iam::${{ matrix.aws_account_id }}:role/${{ matrix.aws_role_name }}
-      tf_dir: "deploy/${{ matrix.stack }}"
-      tf_backend_config_files: "deploy/${{ matrix.stack }}/environments/${{ matrix.environment }}.s3.tfbackend"
-      tf_var_files: "deploy/${{ matrix.stack }}/environments/${{ matrix.environment }}.tfvars"
+      tf_dir: "deploy/infra"
+      tf_backend_config_files: "deploy/infra/environments/${{ matrix.environment }}.s3.tfbackend"
+      tf_var_files: "deploy/infra/environments/${{ matrix.environment }}.tfvars"
       {%- endif %}


### PR DESCRIPTION
bug: Fixing `include` in workflows, since the way we intended use it is not correct. Check [doc](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrixinclude) for further details.